### PR TITLE
fix: edit logo url to correctly display it in other pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@ description: Climate Change Economics home page
     data-theme="{{ site.theme-color }}"
     style="{% if page.header-img %}background: url({{ page.header-img | relative_url }}) no-repeat center center; background-size: cover;{% endif %}"
 >
-    <img src="assets/img/cce_logo_transparent.png"  alt="logo" class="logo-in-header middle-align">
+    <img src="{{ '/assets/img/cce_logo_transparent.png' | relative_url }}"  alt="logo" class="logo-in-header middle-align">
     <p class="logo-text">气候变化经济学论坛</p>
 </div>
 


### PR DESCRIPTION
Currently the logo can't be shown on the second page.

![image](https://user-images.githubusercontent.com/17144939/116785150-8ff13f00-aaca-11eb-802f-f9436e891269.png)

This PR should fix this issue